### PR TITLE
Update librosa requirement section 

### DIFF
--- a/3_extract_audio_features.ipynb
+++ b/3_extract_audio_features.ipynb
@@ -339,7 +339,7 @@
     "                feature_list.append(sig_mean)  # sig_mean\n",
     "                feature_list.append(np.std(y))  # sig_std\n",
     "\n",
-    "                rmse = librosa.feature.rmse(y + 0.0001)[0]\n",
+    "                rmse = librosa.feature.rms(y + 0.0001)[0]\n",
     "                feature_list.append(np.mean(rmse))  # rmse_mean\n",
     "                feature_list.append(np.std(rmse))  # rmse_std\n",
     "\n",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All the experiments have been tested using the following libraries:
 - numpy==1.16.2
 - jupyter==1.0.0
 - pandas==0.24.1
-- librosa==0.6.3
+- librosa==0.7.0
 
 To avoid conflicts, it is recommended to setup a new python virtual environment to install these libraries. Once the env is setup, run `pip install -r requirements.txt` to install the dependencies.
 


### PR DESCRIPTION
According to the librosa change log for .7.0 >> (Root mean square error (rmse) has been renamed to rms)